### PR TITLE
New tested devices: Dell Latitude 5491 and 5480

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ To disable the reader replace `on` with `off`.
 Currently only the following devices were tested and are known to work:
 
 * `0a5c:5834`
+* `0a5c:5832`
 
 Firmware update (done during driver installation on Windows) may be required.
 
@@ -33,6 +34,7 @@ Firmware update (done during driver installation on Windows) may be required.
 * Dell Latitude E7470
 * Dell Latitude 7280
 * Dell Latitude 5491
+* Dell Latitude 5480 (with `0a5c:5832`)
 
 ## How it works?
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Firmware update (done during driver installation on Windows) may be required.
 
 * Dell Latitude E7470
 * Dell Latitude 7280
+* Dell Latitude 5491
 
 ## How it works?
 

--- a/bcm20795.py
+++ b/bcm20795.py
@@ -16,6 +16,7 @@ import usb.util
 
 SUPPORTED_DEVICES = [
 	{'idVendor': 0x0A5C, 'idProduct': 0x5834},
+	{'idVendor': 0x0A5C, 'idProduct': 0x5832},
 ]
 
 logging.basicConfig(level=logging.DEBUG)


### PR DESCRIPTION
I was able to test successfully those Dell laptops.

5491 worked out of the box! :heavy_check_mark: 

The Latitude 5480 needed manually editing the `DEVICE_ID` to `0x5832`.