### PR TITLE
Add support for the NFC reader in a Dell Latitude 5310 2-in-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,14 @@ Currently only the following devices were tested and are known to work:
 
 * `0a5c:5832` (ControlVault 2),
 * `0a5c:5834` (ControlVault 2),
+* `0a5c:5842` (ControlVault 3).
 * `0a5c:5843` (ControlVault 3).
 
 Firmware update (done during driver installation on Windows) may be required.
 
 ## Tested on
 
+* Dell Latitude 5310 2-in-1
 * Dell Latitude 5480
 * Dell Latitude 5491
 * Dell Latitude 7280

--- a/nfc.py
+++ b/nfc.py
@@ -19,6 +19,7 @@ class UsbDeviceFinder:
 	SUPPORTED_DEVICES = [
 		UsbDeviceMatcher({'idVendor': 0x0A5C, 'idProduct': 0x5832}, lambda device: __import__('cv2').ControlVault2(device)),
 		UsbDeviceMatcher({'idVendor': 0x0A5C, 'idProduct': 0x5834}, lambda device: __import__('cv2').ControlVault2(device)),
+		UsbDeviceMatcher({'idVendor': 0x0A5C, 'idProduct': 0x5842}, lambda device: __import__('cv3').ControlVault3(device)),
 		UsbDeviceMatcher({'idVendor': 0x0A5C, 'idProduct': 0x5843}, lambda device: __import__('cv3').ControlVault3(device)),
 	]
 


### PR DESCRIPTION
My Latitude 5310 2-in-1 has an NFC reader with ID 0a5c:5842.  This seems to work correctly if I treat it the same as 0a5c:5843, so do that.  Also update documentation to match.